### PR TITLE
add support for building against mfem and omegah with cuda enabled

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,9 +12,19 @@ project(inclusion_solver VERSION 1.0.0 LANGUAGES CXX)
 set(CMAKE_MODULE_PATH
   ${CMAKE_MODULE_PATH} "${CMAKE_CURRENT_SOURCE_DIR}/cmake/")
 
-find_package(HYPRE REQUIRED)
-find_package(METIS REQUIRED)
+find_package(Omega_h REQUIRED)
+if(NOT MFEM_USE_CUDA)
+  #HACK: Clear the omegah compilation flags that it passes to cuda.
+  set_property(TARGET Omega_h::omega_h PROPERTY INTERFACE_COMPILE_OPTIONS "")
+endif()
 
+if(MFEM_USE_CUDA)
+  if(NOT OMEGA_H_USE_CUDA)
+    #TODO we may want to support mfem+cuda and omegah without cuda at some
+    # point... possibly for debugging
+    message(FATAL_ERROR "MFEM has CUDA enabled but Omega_h does not...exiting")
+  endif()
+endif()
 
 if (MFEM_PREFIX)
 find_package(MFEM REQUIRED CONFIG PATHS ${MFEM_PREFIX} NO_DEFAULT_PATH)
@@ -28,20 +38,24 @@ find_package(
     )
 endif()
 
+
 message(STATUS "MFEM INCLUDE is ${MFEM_INCLUDE_DIRS} ")
 message(STATUS "MFEM LIBRARY is ${MFEM_LIBRARY_DIR} ")
 
 
-add_library(inclusion_solver STATIC
-  ${CMAKE_CURRENT_SOURCE_DIR}/inclusion_solver.cpp
-  ${CMAKE_CURRENT_SOURCE_DIR}/pfem_extras.cpp)
-include_directories(${MFEM_INCLUDE_DIRS})
-target_link_libraries(inclusion_solver ${MFEM_LIBRARY_DIR}/libmfem.a)
+add_library(inclusion_solver STATIC inclusion_solver.cpp pfem_extras.cpp)
+target_link_libraries(inclusion_solver mfem)
+if(MFEM_USE_CUDA)
+  enable_language(CUDA)
+  set_source_files_properties(inclusion_solver.cpp pfem_extras.cpp PROPERTIES LANGUAGE CUDA)
+  set_property(TARGET inclusion_solver PROPERTY CUDA_ARCHITECTURES ${INCLUSION_SOLVER_CUDA_ARCH})
+endif()
 
-add_executable(inclusion ${CMAKE_CURRENT_SOURCE_DIR}/inclusion.cpp)
+add_executable(inclusion inclusion.cpp)
 include_directories(${MFEM_INCLUDE_DIRS})
-target_link_libraries(inclusion 
-  ${MFEM_LIBRARY_DIR}/libmfem.a
-  ${HYPRE_LIBRARIES}
-  ${METIS_LIBRARIES}
-  inclusion_solver)
+target_link_libraries(inclusion inclusion_solver)
+if(MFEM_USE_CUDA)
+  set_source_files_properties(inclusion.cpp PROPERTIES LANGUAGE CUDA)
+  set_property(TARGET inclusion PROPERTY CUDA_ARCHITECTURES ${INCLUSION_SOLVER_CUDA_ARCH})
+endif()
+

--- a/README.md
+++ b/README.md
@@ -16,6 +16,44 @@ If things run successfully there should be an executable named `inclusion` in yo
 
 **Note** both the build for this example and the build of MFEM have to use consistent dependencies (e.g. the same Hypre, Metis, etc) to avoid build problems.
 
+### Example environment and config for build with CUDA enabled in MFEM and Omega\_h
+
+environment (SCOREC RHEL7)
+
+```
+module use /opt/scorec/spack/v0132/lmod/linux-rhel7-x86_64/Core
+module load gcc mpich cmake hypre parmetis cuda/10.2 
+
+pmetis=${PARMETIS_ROOT}
+export CMAKE_PREFIX_PATH=$CMAKE_PREFIX_PATH:$pmetis
+
+export HYPRE_DIR=$HYPRE_ROOT
+unset HYPRE_ROOT
+export METIS_DIR=$METIS_ROOT
+unset METIS_ROOT
+export ZLIB_DIR=$ZLIB_ROOT
+unset ZLIB_ROOT 
+
+export MPICH_CXX=g++
+export CMAKE_PREFIX_PATH=$CMAKE_PREFIX_PATH:/path/to/omegah/install
+```
+
+config.sh
+
+```
+export MFEM_INSTALL_PATH=/path/to/mfem/install/
+flags="-g -O0"
+cmake $1 \
+  -DCMAKE_BUILD_TYPE=Debug \
+  -DMFEM_PREFIX=$MFEM_INSTALL_PATH \
+  -DCMAKE_VERBOSE_MAKEFILE:BOOL=OFF \
+  -DCMAKE_INSTALL_PREFIX:PATH=$PWD/install \
+  -DCMAKE_CXX_COMPILER=mpicxx \
+  -DCMAKE_CXX_FLAGS="${flags}" \
+  -DCMAKE_EXE_LINKER_FLAGS="-lpthread ${flags}" \
+  -DINCLUSION_SOLVER_CUDA_ARCH=75
+```
+
 ## Example Meshes
 
 You can find two example meshes in the folder `./meshes`. The first one `setup_1x1_global_coarse_template_mesh.mesh` has only 1 ellipsoidal inclusion in the substrate. The second one `setup_5x5_global_coarse_template_mesh.mesh` has a 5by5 array of identical ellipsoidal inclusions in the substrate. Both of these meshes have appropriate classification information.

--- a/pfem_extras.cpp
+++ b/pfem_extras.cpp
@@ -438,7 +438,7 @@ void VisualizeField(socketstream &sock, const char *vishost, int visport,
       }
 
       pmesh.PrintAsOne(sock);
-      gf.SaveAsOne(sock);
+      //gf.SaveAsOne(sock);
 
       if (myid == 0 && newly_opened)
       {


### PR DESCRIPTION
This PR adds cmake support for building against MFEM (SCOREC fork omegh-dev @ 9158073) and Omega_h (SCOREC fork master @ e889123) with CUDA enabled.  The executable builds but I have not tried running it.

This commit:

https://github.com/mortezah/inclusion_solver/commit/7e26e4d8c351b126afa567f640e04cfd33554c15

is a hack to avoid the following compilation error:

```
/space/cwsmith/omegahMfem/inclusion_solver/pfem_extras.cpp(441): error: the object has type qualifiers that are not compatible with the member function mfem::ParGridFunction::SaveAsOne
            object type is: const mfem::ParGridFunction
```